### PR TITLE
Added the ability to patch type constructors

### DIFF
--- a/src/MClient/Core/PatchSystem/AutoPatcher/MAutoPatchHandler.cs
+++ b/src/MClient/Core/PatchSystem/AutoPatcher/MAutoPatchHandler.cs
@@ -28,7 +28,11 @@ namespace MClient.Core.PatchSystem.AutoPatcher
 
                 foreach (var attribute in attributes)
                 {
-                    var mPatch = AccessTools.DeclaredMethod(attribute.Type, attribute.Method, attribute.Params);
+                    MethodBase mPatch;
+                    if (attribute.Method is ".ctor" or "")
+                        mPatch = AccessTools.DeclaredConstructor(attribute.Type, attribute.Params);
+                    else 
+                        mPatch = AccessTools.DeclaredMethod(attribute.Type, attribute.Method, attribute.Params);
 
                     if (mPatch is null)
                     {


### PR DESCRIPTION
By using the method name ".ctor" or "" the mod will look for the constructor of the given type rather than methods it has.
Keep in mind that parameters still have to be supplied.
I am also unsure if this works with static types.